### PR TITLE
AI: en la doc hay que dejar claro que tiktok en modo draft no deja pponer title ni caption ni nada eso, solo te deja subir el video y ya pa que lo edites desde la app que se te queda en la bandeja

### DIFF
--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -1357,8 +1357,6 @@ export class UploadPost implements INodeType {
 					}
 				},
 			},
-			// Removed platform filter (not supported by API)
-			// Removed status filter (not supported by API)
 			{
 				displayName: 'Page',
 				name: 'historyPage',
@@ -1424,7 +1422,6 @@ export class UploadPost implements INodeType {
 					description: 'Platforms to fetch analytics for (comma-joined in request)',
 					displayOptions: { show: { operation: ['getAnalytics'] } },
 			},
-			// Removed from/to date filters (not supported by API)
 
 			// Create user
 			{
@@ -1850,7 +1847,7 @@ export class UploadPost implements INodeType {
 					{ name: 'Media Upload (Inbox)', value: 'MEDIA_UPLOAD' },
 				],
 				default: 'DIRECT_POST',
-				description: 'Choose TikTok posting mode for video',
+				description: 'Choose TikTok posting mode for video. Note: In MEDIA_UPLOAD (Draft) mode, title and caption are ignored and must be set in the TikTok app.',
 				displayOptions: {
 					show: {
 						operation: ['uploadVideo'],


### PR DESCRIPTION
```markdown
## Docs: Clarify TikTok Draft Mode Restrictions for Video Uploads

This update enhances the documentation for the 'UploadPost' node, specifically addressing behavior for TikTok video uploads when using the 'MEDIA_UPLOAD' (Draft) mode.

**Purpose:**
To prevent user confusion and provide accurate information regarding TikTok's API limitations, the description for the TikTok posting mode option has been updated. This clarifies that when a video is uploaded to TikTok in 'MEDIA_UPLOAD' (Draft) mode, any titles or captions provided in the n8n workflow are ignored. The video is instead pushed to the user's TikTok app inbox, where titles and captions must be set manually.

**Changes:**
*   Updated the description for the 'Choose TikTok posting mode for video' option in `UploadPost.node.ts` to explicitly state that title and caption are ignored in 'MEDIA_UPLOAD' (Draft) mode and must be set within the TikTok app.
```