### PR TITLE
AI: Tener estadisticas de un post concreto para todas las redes sociales y no por plataforma

### DIFF
--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -764,6 +764,15 @@ const buildMonitoringRequest = (ctx: ExecutionContext): RequestConfig => {
 				waitForCompletion: false,
 			};
 		}
+		case 'getPostAnalytics': {
+			const requestId = ctx.node.getNodeParameter('requestId', ctx.itemIndex) as string;
+			return {
+				endpoint: `/analytics/post/${requestId}`,
+				method: 'GET',
+				isUploadOperation: false,
+				waitForCompletion: false,
+			};
+		}
 		case 'getHistory': {
 			const page = ctx.node.getNodeParameter('historyPage', ctx.itemIndex, 1) as number;
 			const limit = ctx.node.getNodeParameter('historyLimit', ctx.itemIndex, 20) as number;
@@ -1051,6 +1060,7 @@ export class UploadPost implements INodeType {
 						{ name: 'Edit Scheduled Post', value: 'editScheduled', action: 'Edit scheduled post', description: 'Edit schedule details (like date/time) by job ID' },
 						{ name: 'Get Analytics', value: 'getAnalytics', action: 'Get analytics', description: 'Retrieve aggregated analytics for uploads' },
 					{ name: 'Get Upload History', value: 'getHistory', action: 'Get upload history', description: 'List past uploads with optional filters' },
+						{ name: 'Get Post Analytics', value: 'getPostAnalytics', action: 'Get post analytics', description: 'Retrieve aggregated analytics for a specific post execution' },
 					{ name: 'Get Upload Status', value: 'getStatus', action: 'Get upload status', description: 'Check the status of an upload using the request_id' },
 						{ name: 'List Scheduled Posts', value: 'listScheduled', action: 'List scheduled posts', description: 'List your scheduled (future) posts' },
 				],
@@ -1353,7 +1363,7 @@ export class UploadPost implements INodeType {
 				description: 'The request_id returned by an async upload to query its status',
 				displayOptions: {
 					show: {
-						operation: ['getStatus']
+						operation: ['getStatus', 'getPostAnalytics']
 					}
 				},
 			},


### PR DESCRIPTION
## Feature: Cross-Platform Post Analytics

This PR introduces a new operation to the `UploadPost` node, enabling users to retrieve aggregated statistics for a specific post across all connected social networks. This enhancement addresses the need for a unified view of post performance, moving beyond individual platform metrics.

### Summary of Changes

A new operation, "Get Post Analytics," has been added, allowing users to query comprehensive analytics for a particular post identified by its `requestId`. This provides a streamlined way to assess post engagement and reach holistically.

### Changes:
*   **Added `getPostAnalytics` operation:** A new option `Get Post Analytics` is now available in the `UploadPost` node's operations.
*   **New API Endpoint Integration:** Implemented support for the `/analytics/post/{requestId}` GET endpoint to fetch cross-platform post statistics.
*   **`requestId` Parameter Update:** The `requestId` parameter is now applicable to both `getStatus` and the new `getPostAnalytics` operations.