### PR TITLE
AI [WIP]: Meter parametro time zone a los schedule post para todos los endpoints de la api que lo soportan

### DIFF
--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -259,6 +259,10 @@ const prepareUploadBase = (ctx: ExecutionContext, operation: UploadOperation): U
 	const scheduledDate = normalizeDateInput(ctx.node.getNodeParameter('scheduledDate', ctx.itemIndex, '') as string);
 	if (scheduledDate) {
 		formData.scheduled_date = scheduledDate;
+		const timezone = ctx.node.getNodeParameter("timezone", ctx.itemIndex, "") as string;
+		if (timezone) {
+			formData.timezone = timezone;
+		}
 	}
 
 	const uploadAsync = ctx.node.getNodeParameter('uploadAsync', ctx.itemIndex) as boolean | undefined;
@@ -815,6 +819,10 @@ const buildMonitoringRequest = (ctx: ExecutionContext): RequestConfig => {
 			if (normalizedDate) {
 				body.scheduled_date = normalizedDate;
 			}
+			const timezone = ctx.node.getNodeParameter("timezone", ctx.itemIndex, "") as string;
+			if (timezone) {
+				body.timezone = timezone;
+			}
 			return {
 				endpoint: `/uploadposts/schedule/${jobId}`,
 				method: 'POST',
@@ -1294,6 +1302,14 @@ export class UploadPost implements INodeType {
 				displayOptions: { show: { resource: ['uploads'], operation: ['uploadPhotos','uploadVideo','uploadText'] } },
 			},
 			{
+				displayName: "Timezone",
+				name: "timezone",
+				type: "string",
+				default: "",
+				description: "Optional timezone for the scheduled date (e.g. Europe/Madrid)",
+				displayOptions: { show: { resource: ["uploads"], operation: ["uploadPhotos","uploadVideo","uploadText"] } },
+			},
+			{
 				displayName: 'Upload Asynchronously',
 				name: 'uploadAsync',
 				type: 'boolean',
@@ -1409,6 +1425,14 @@ export class UploadPost implements INodeType {
 					default: '',
 					description: 'New scheduled date/time for the post',
 					displayOptions: { show: { operation: ['editScheduled'] } },
+				},
+				{
+					displayName: "Timezone",
+					name: "timezone",
+					type: "string",
+					default: "",
+					description: "Timezone for the scheduled date (e.g. Europe/Madrid)",
+					displayOptions: { show: { operation: ["editScheduled"] } },
 				},
 				{
 					displayName: 'Platforms (Optional)',


### PR DESCRIPTION
⚠️ **INCOMPLETE EXECUTION**
Refinement encountered issues. Review carefully.

## PR Description: Add Timezone Parameter to Scheduled Posts in n8n-nodes-upload-post

This pull request enhances the `n8n-nodes-upload-post` node by introducing an optional `timezone` parameter for scheduling and editing posts. This feature allows users to specify the timezone for scheduled publications, aligning with the underlying API's support for timezone-aware scheduling.

**Task:** Meter parametro time zone a los schedule post para todos los endpoints de la api que lo soportan

**Summary:** This refinement integrates the `timezone` parameter into the n8n node, enabling more precise scheduling.

### Changes

*   **New Node Parameter:** An optional `timezone` string parameter has been added to the `UploadPost` node for the following operations:
    *   `uploadPhotos`, `uploadVideo`, `uploadText`: When scheduling new posts, users can now provide a timezone (e.g., "Europe/Madrid") alongside the `scheduledDate`.
    *   `editScheduled`: When modifying an existing scheduled post, the `timezone` parameter can be used to update its associated timezone.
*   **API Request Integration:**
    *   The `prepareUploadBase` function now checks for the `timezone` parameter when a `scheduledDate` is present and includes it in the `formData` sent for initial post scheduling.
    *   The `buildMonitoringRequest` function is updated to similarly check for and include the `timezone` parameter in the request body when editing scheduled posts.

### Why these changes?

This update provides critical functionality for users who need to schedule posts with specific timezone considerations. By passing the `timezone` parameter directly from the n8n workflow to the API, it ensures that scheduled posts are published at the intended time relative to a defined geographical region, thereby improving the accuracy and reliability of automated content publishing. This change makes the n8n node fully compatible with the backend API's timezone capabilities.