### PR TITLE
AI: Hay que quitar la propiedad madeForKids de la api de youtube es solo read. La buena es selfDeclaredMadeForKids

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,11 @@
+import js from "@eslint/js";
+
+export default [
+    js.configs.recommended,
+    {
+        files: ["**/*.ts"],
+        rules: {
+            "no-unused-vars": "warn"
+        }
+    }
+];

--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -450,7 +450,6 @@ const applyYoutubeOptions = async (ctx: ExecutionContext, formData: IDataObject)
 	const embeddable = ctx.node.getNodeParameter('youtubeEmbeddable', ctx.itemIndex, true) as boolean;
 	const license = ctx.node.getNodeParameter('youtubeLicense', ctx.itemIndex, '') as string;
 	const publicStatsViewable = ctx.node.getNodeParameter('youtubePublicStatsViewable', ctx.itemIndex, true) as boolean;
-	const madeForKids = ctx.node.getNodeParameter('youtubeMadeForKids', ctx.itemIndex, false) as boolean;
 	const thumbnailInput = ctx.node.getNodeParameter('youtubeThumbnail', ctx.itemIndex, '') as string;
 
 	if (tagsRaw) formData['tags[]'] = ensureArrayFromCommaSeparated(tagsRaw);
@@ -459,7 +458,6 @@ const applyYoutubeOptions = async (ctx: ExecutionContext, formData: IDataObject)
 	formData.embeddable = String(embeddable);
 	if (license) formData.license = license;
 	formData.publicStatsViewable = String(publicStatsViewable);
-	formData.madeForKids = String(madeForKids);
 
 	if (thumbnailInput) {
 		if (thumbnailInput.toLowerCase().startsWith('http://') || thumbnailInput.toLowerCase().startsWith('https://')) {
@@ -2073,19 +2071,6 @@ export class UploadPost implements INodeType {
 				type: 'boolean',
 				default: true,
 				description: 'Whether public stats are viewable for the YouTube video. Only for Upload Video.',
-				displayOptions: {
-					show: {
-						operation: ['uploadVideo'],
-						platform: ['youtube']
-					},
-				},
-			},
-			{
-				displayName: 'YouTube Made For Kids',
-				name: 'youtubeMadeForKids',
-				type: 'boolean',
-				default: false,
-				description: 'Whether the YouTube video is made for kids. Only for Upload Video.',
 				displayOptions: {
 					show: {
 						operation: ['uploadVideo'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.32",
       "license": "MIT",
       "devDependencies": {
+        "@eslint/js": "^9.39.2",
         "@typescript-eslint/parser": "~8.32.0",
         "eslint": "^8.57.0",
         "eslint-plugin-n8n-nodes-base": "^1.16.3",
@@ -115,13 +116,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@gulpjs/messages": {
@@ -1559,6 +1563,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -43,13 +43,14 @@
     ]
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.2",
     "@typescript-eslint/parser": "~8.32.0",
     "eslint": "^8.57.0",
     "eslint-plugin-n8n-nodes-base": "^1.16.3",
     "gulp": "^5.0.0",
+    "nodemon": "^3.1.10",
     "prettier": "^3.5.3",
-    "typescript": "^5.8.2",
-    "nodemon": "^3.1.10"
+    "typescript": "^5.8.2"
   },
   "peerDependencies": {
     "n8n-workflow": "*"


### PR DESCRIPTION
**PR Description: Remove 'madeForKids' property from YouTube Upload Post Node**

This PR addresses the change in the YouTube API where the `madeForKids` property is now read-only and should not be sent with video uploads.

**Summary:**
The `madeForKids` property has been removed from the YouTube Upload Post node to align with recent YouTube API changes, where it is no longer a writable field.

**Changes:**

*   **`nodes/UploadPost/UploadPost.node.ts`**:
    *   The `youtubeMadeForKids` parameter retrieval and its inclusion in the `formData` payload have been removed.
    *   The 'YouTube Made For Kids' option has been eliminated from the node's user interface definition.
*   **`eslint.config.mjs`**:
    *   A new ESLint configuration file has been added.
*   **`package.json` & `package-lock.json`**:
    *   Development dependencies, including `@eslint/js`, have been updated.