### PR TITLE
AI: Pinterest upload "Alt Text" parameter in n8n node

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,40 @@ Agent → Content Generation → Upload Post Node → Multiple Platforms
 }
 ```
 
+
+### Pinterest Upload with Alt Text
+
+```json
+{
+  "operation": "uploadPhotos",
+  "user": "design_profile",
+  "platform": ["pinterest"],
+  "title": "Modern Home Office Setup",
+  "description": "Minimalist workspace inspiration for remote work",
+  "photos": "{{ $binary.data }}",
+  "pinterestBoardId": "1234567890",
+  "pinterestAltText": "A clean white desk with a laptop, plant, and notebook arranged neatly",
+  "pinterestLink": "https://example.com/home-office-tips"
+}
+```
+
+### Pinterest Video Upload
+
+```json
+{
+  "operation": "uploadVideo",
+  "user": "creator_profile",
+  "platform": ["pinterest"],
+  "title": "DIY Desk Makeover Tutorial",
+  "description": "Transform your workspace in 10 minutes",
+  "video": "{{ $binary.video }}",
+  "pinterestBoardId": "1234567890",
+  "pinterestAltText": "Step-by-step video showing desk transformation with tools and materials",
+  "pinterestLink": "https://example.com/diy-desk",
+  "pinterestCoverImageUrl": "https://example.com/cover.jpg"
+}
+```
+
 ## Agent Best Practices
 
 ### Content Preparation

--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -304,6 +304,10 @@ const applyPinterestOptions = (ctx: ExecutionContext, operation: UploadOperation
 	if (pinterestLink) {
 		formData.pinterest_link = pinterestLink;
 	}
+	const pinterestAltText = ctx.node.getNodeParameter('pinterestAltText', ctx.itemIndex, '') as string;
+	if (pinterestAltText) {
+		formData.pinterest_alt_text = pinterestAltText;
+	}
 	if (operation === 'uploadVideo') {
 		const pinterestCoverImageUrl = ctx.node.getNodeParameter('pinterestCoverImageUrl', ctx.itemIndex, '') as string;
 		const pinterestCoverImageContentType = ctx.node.getNodeParameter('pinterestCoverImageContentType', ctx.itemIndex, '') as string;
@@ -2263,6 +2267,19 @@ export class UploadPost implements INodeType {
 				type: 'string',
 				default: '',
 				description: 'Optional link to attach to the Pinterest pin',
+				displayOptions: {
+					show: {
+						operation: ['uploadPhotos', 'uploadVideo'],
+						platform: ['pinterest']
+					}
+				},
+			},
+			{
+				displayName: 'Pinterest Alt Text (Photo/Video)',
+				name: 'pinterestAltText',
+				type: 'string',
+				default: '',
+				description: 'Optional alt text for accessibility. Describes the image for screen readers and improves SEO.',
 				displayOptions: {
 					show: {
 						operation: ['uploadPhotos', 'uploadVideo'],


### PR DESCRIPTION
**PR: Add Alt Text Parameter for Pinterest Uploads**

This PR introduces support for alt text on Pinterest uploads within the n8n node, enhancing accessibility and SEO for pinned content.

### Changes

*   **AGENTS.md**: Added two JSON usage examples demonstrating how to use the new `pinterestAltText` parameter for both photo and video uploads.
*   **UploadPost.node.ts**:
    *   **Feature**: Added a new `pinterestAltText` parameter to the node's configuration. It displays for `uploadPhotos` and `uploadVideo` operations on the `pinterest` platform.
    *   **Implementation**: Updated the `applyPinterestOptions` function to read the `pinterestAltText` value and map it to the `pinterest_alt_text` form data field in the backend API request.