### PR TITLE
Enable Pinterest Alt Text

### DIFF
--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -300,6 +300,10 @@ const applyPinterestOptions = (ctx: ExecutionContext, operation: UploadOperation
 	if (pinterestBoardId) {
 		formData.pinterest_board_id = pinterestBoardId;
 	}
+	const pinterestAltText = ctx.node.getNodeParameter('pinterestAltText', ctx.itemIndex, '') as string;
+	if (pinterestAltText) {
+		formData.pinterest_alt_text = pinterestAltText;
+	}
 	const pinterestLink = ctx.node.getNodeParameter('pinterestLink', ctx.itemIndex, '') as string;
 	if (pinterestLink) {
 		formData.pinterest_link = pinterestLink;
@@ -1252,6 +1256,14 @@ export class UploadPost implements INodeType {
 				default: '',
 				description: 'Override for YouTube video description. When empty we default to the main title.',
 				displayOptions: { show: { operation: ['uploadVideo'], platform: ['youtube'] } },
+			},
+			{
+				displayName: 'Pinterest Alt Text (Override)',
+				name: 'pinterestAltText',
+				type: 'string',
+				default: '',
+				description: 'Optional override for Pinterest alt text',
+				displayOptions: { show: { operation: ['uploadPhotos','uploadVideo'], platform: ['pinterest'] } },
 			},
 			{
 				displayName: 'Pinterest Description (Override)',


### PR DESCRIPTION
**Feat: Pinterest Alt Text Parameter for Uploads**

This PR introduces the functionality for users to specify 'Alt Text' when uploading content to Pinterest via the `UploadPost` node. This enhancement improves accessibility and discoverability for Pins published through n8n.

**Changes:**

*   **`nodes/UploadPost/UploadPost.node.ts`**:
    *   A new `pinterestAltText` string parameter has been added to the node's schema. This parameter is displayed in the node's interface specifically for Pinterest photo and video upload operations.
    *   The `applyPinterestOptions` function was updated to capture the user-provided `pinterestAltText` and include it as `pinterest_alt_text` in the API request payload sent for Pinterest uploads.