### PR TITLE
Add First Comment field per platform

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,12 @@
+import { FlatCompat } from '@eslint/eslintrc';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const compat = new FlatCompat({
+	baseDirectory: __dirname,
+});
+
+export default [...compat.extends('./.eslintrc.js')];

--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -203,6 +203,20 @@ const DESCRIPTION_OVERRIDES: Array<{
 	{ platform: 'pinterest', param: 'pinterestDescription', field: 'pinterest_description', operations: ['uploadPhotos', 'uploadVideo'] },
 ];
 
+const FIRST_COMMENT_OVERRIDES: Array<{
+	platform: string;
+	param: string;
+	field: string;
+}> = [
+	{ platform: 'instagram', param: 'instagramFirstComment', field: 'instagram_first_comment' },
+	{ platform: 'facebook', param: 'facebookFirstComment', field: 'facebook_first_comment' },
+	{ platform: 'threads', param: 'threadsFirstComment', field: 'threads_first_comment' },
+	{ platform: 'bluesky', param: 'blueskyFirstComment', field: 'bluesky_first_comment' },
+	{ platform: 'reddit', param: 'redditFirstComment', field: 'reddit_first_comment' },
+	{ platform: 'x', param: 'xFirstComment', field: 'x_first_comment' },
+	{ platform: 'youtube', param: 'youtubeFirstComment', field: 'youtube_first_comment' },
+];
+
 const getFilteredPlatforms = (operation: UploadOperation, platforms: string[]): string[] => {
 	const allowed = PLATFORM_SUPPORT[operation] ?? [];
 	return platforms.filter(platform => allowed.includes(platform));
@@ -232,6 +246,16 @@ const applyDescriptionOverrides = (ctx: ExecutionContext, operation: UploadOpera
 	for (const override of DESCRIPTION_OVERRIDES) {
 		if (!platforms.includes(override.platform)) continue;
 		if (override.operations && !override.operations.includes(operation)) continue;
+		const value = ctx.node.getNodeParameter(override.param, ctx.itemIndex, '') as string;
+		if (value) {
+			formData[override.field] = value;
+		}
+	}
+};
+
+const applyFirstCommentOverrides = (ctx: ExecutionContext, platforms: string[], formData: IDataObject) => {
+	for (const override of FIRST_COMMENT_OVERRIDES) {
+		if (!platforms.includes(override.platform)) continue;
 		const value = ctx.node.getNodeParameter(override.param, ctx.itemIndex, '') as string;
 		if (value) {
 			formData[override.field] = value;
@@ -286,6 +310,7 @@ const prepareUploadBase = (ctx: ExecutionContext, operation: UploadOperation): U
 
 	applyTitleOverrides(ctx, operation, platforms, formData);
 	applyDescriptionOverrides(ctx, operation, platforms, formData);
+	applyFirstCommentOverrides(ctx, platforms, formData);
 
 	const waitForCompletion = ctx.node.getNodeParameter('waitForCompletion', ctx.itemIndex, false) as boolean;
 	const pollInterval = ctx.node.getNodeParameter('pollInterval', ctx.itemIndex, 10) as number;
@@ -1338,6 +1363,64 @@ export class UploadPost implements INodeType {
 				default: '',
 				description: 'Override for Pinterest pin description (and alt text fallback). When empty we re-use the main title.',
 				displayOptions: { show: { operation: ['uploadPhotos','uploadVideo'], platform: ['pinterest'] } },
+			},
+
+			// Platform-specific First Comment Overrides
+			{
+				displayName: 'Instagram First Comment (Override)',
+				name: 'instagramFirstComment',
+				type: 'string',
+				default: '',
+				description: 'Optional override for Instagram first comment. Overrides the global First Comment for Instagram.',
+				displayOptions: { show: { operation: ['uploadPhotos','uploadVideo','uploadText'], platform: ['instagram'] } },
+			},
+			{
+				displayName: 'Facebook First Comment (Override)',
+				name: 'facebookFirstComment',
+				type: 'string',
+				default: '',
+				description: 'Optional override for Facebook first comment. Overrides the global First Comment for Facebook.',
+				displayOptions: { show: { operation: ['uploadPhotos','uploadVideo','uploadText'], platform: ['facebook'] } },
+			},
+			{
+				displayName: 'Threads First Comment (Override)',
+				name: 'threadsFirstComment',
+				type: 'string',
+				default: '',
+				description: 'Optional override for Threads first comment. Overrides the global First Comment for Threads.',
+				displayOptions: { show: { operation: ['uploadPhotos','uploadVideo','uploadText'], platform: ['threads'] } },
+			},
+			{
+				displayName: 'Bluesky First Comment (Override)',
+				name: 'blueskyFirstComment',
+				type: 'string',
+				default: '',
+				description: 'Optional override for Bluesky first comment. Overrides the global First Comment for Bluesky.',
+				displayOptions: { show: { operation: ['uploadPhotos','uploadVideo','uploadText'], platform: ['bluesky'] } },
+			},
+			{
+				displayName: 'Reddit First Comment (Override)',
+				name: 'redditFirstComment',
+				type: 'string',
+				default: '',
+				description: 'Optional override for Reddit first comment. Overrides the global First Comment for Reddit.',
+				displayOptions: { show: { operation: ['uploadPhotos','uploadVideo','uploadText'], platform: ['reddit'] } },
+			},
+			{
+				displayName: 'X First Comment (Override)',
+				name: 'xFirstComment',
+				type: 'string',
+				default: '',
+				description: 'Optional override for X first comment. Overrides the global First Comment for X.',
+				displayOptions: { show: { operation: ['uploadPhotos','uploadVideo','uploadText'], platform: ['x'] } },
+			},
+			{
+				displayName: 'YouTube First Comment (Override)',
+				name: 'youtubeFirstComment',
+				type: 'string',
+				default: '',
+				description: 'Optional override for YouTube first comment. Overrides the global First Comment for YouTube.',
+				displayOptions: { show: { operation: ['uploadVideo'], platform: ['youtube'] } },
 			},
 
 

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "dev": "tsc --watch",
     "debug": "./debug.sh",
     "format": "prettier nodes credentials --write",
-    "lint": "eslint nodes credentials package.json",
-    "lintfix": "eslint nodes credentials package.json --fix",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint nodes credentials package.json",
+    "lintfix": "ESLINT_USE_FLAT_CONFIG=false eslint nodes credentials package.json --fix",
     "prepublishOnly": "npm run build && npm run lint -c .eslintrc.prepublish.js nodes credentials package.json"
   },
   "files": [


### PR DESCRIPTION
# PR Description: Platform-Specific First Comment Field Overrides

## Overview
This PR introduces platform-specific first comment field support to the n8n Upload Post node, enabling users to customize the first comment independently for each social media platform while maintaining a global default.

## Changes

### Core Feature Implementation
- **Added `FIRST_COMMENT_OVERRIDES` configuration** mapping 7 platforms to their respective first comment field parameters and API fields:
  - Instagram, Facebook, Threads, Bluesky, Reddit, X, and YouTube
  
- **Implemented `applyFirstCommentOverrides()` function** to conditionally apply platform-specific first comment values to the request payload, similar to existing title and description overrides

- **Integrated override logic** into the `prepareUploadBase()` workflow to execute during upload preparation across all supported operations

### User-Facing Fields
Added 7 new optional node parameters for platform-specific first comment overrides:
- Each parameter includes context-aware display conditions tied to applicable platforms and operations
- YouTube first comment only shows for `uploadVideo` operation
- Other platforms support `uploadPhotos`, `uploadVideo`, and `uploadText` operations
- All fields include descriptive help text explaining they override the global first comment setting

### Development Configuration
- **Added `eslint.config.mjs`** to support ESLint's flat config format for improved configuration management
- **Updated lint scripts** in `package.json` to explicitly use `ESLINT_USE_FLAT_CONFIG=false` for compatibility

## Technical Details
The implementation follows the established pattern used for description overrides, ensuring consistency with existing codebase conventions. Each platform-specific override is optional and only applied when explicitly set, preserving backward compatibility with global first comment settings.

---

**Branch:** `ai-add-first-comment-per-platform-002c8926`  
**Target:** `staging`