### PR TITLE
Add read-only calendar view for white-label

### DIFF
--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -964,11 +964,19 @@ const buildUserRequest = (ctx: ExecutionContext): RequestConfig => {
 			const logoImage = ctx.node.getNodeParameter('logoImage', ctx.itemIndex, '') as string;
 			const redirectButtonText = ctx.node.getNodeParameter('redirectButtonText', ctx.itemIndex, '') as string;
 			const platforms = ctx.node.getNodeParameter('jwtPlatforms', ctx.itemIndex, []) as string[];
+			const showCalendar = ctx.node.getNodeParameter('showCalendar', ctx.itemIndex, true) as boolean;
+			const readonlyCalendar = ctx.node.getNodeParameter('readonlyCalendar', ctx.itemIndex, false) as boolean;
+			const connectTitle = ctx.node.getNodeParameter('connectTitle', ctx.itemIndex, '') as string;
+			const connectDescription = ctx.node.getNodeParameter('connectDescription', ctx.itemIndex, '') as string;
 			const body: IDataObject = { username };
 			if (redirectUrl) body.redirect_url = redirectUrl;
 			if (logoImage) body.logo_image = logoImage;
 			if (redirectButtonText) body.redirect_button_text = redirectButtonText;
 			if (Array.isArray(platforms) && platforms.length > 0) body.platforms = platforms;
+			body.show_calendar = showCalendar;
+			body.readonly_calendar = readonlyCalendar;
+			if (connectTitle) body.connect_title = connectTitle;
+			if (connectDescription) body.connect_description = connectDescription;
 			return {
 				endpoint: '/uploadposts/users/generate-jwt',
 				method: 'POST',
@@ -1725,6 +1733,38 @@ export class UploadPost implements INodeType {
 				],
 				default: [],
 				description: 'Optional list of platforms to show for connection. Defaults to all supported platforms.',
+				displayOptions: { show: { operation: ['generateJwt'] } },
+			},
+			{
+				displayName: 'Show Calendar View',
+				name: 'showCalendar',
+				type: 'boolean',
+				default: true,
+				description: 'Whether to show the calendar view on the connection page',
+				displayOptions: { show: { operation: ['generateJwt'] } },
+			},
+			{
+				displayName: 'Read-Only Calendar',
+				name: 'readonlyCalendar',
+				type: 'boolean',
+				default: false,
+				description: 'Show only a read-only calendar view (no editing, no account connection). Ideal for sharing with end clients.',
+				displayOptions: { show: { operation: ['generateJwt'], showCalendar: [true] } },
+			},
+			{
+				displayName: 'Connect Title',
+				name: 'connectTitle',
+				type: 'string',
+				default: '',
+				description: 'Optional custom title for the connection page',
+				displayOptions: { show: { operation: ['generateJwt'] } },
+			},
+			{
+				displayName: 'Connect Description',
+				name: 'connectDescription',
+				type: 'string',
+				default: '',
+				description: 'Optional custom description for the connection page',
 				displayOptions: { show: { operation: ['generateJwt'] } },
 			},
 


### PR DESCRIPTION
# PR Description: Read-Only Calendar Support for White-Label Profiles

## Overview
Added read-only calendar mode for white-label clients, enabling profile administrators to restrict end-users from editing or creating scheduled posts while maintaining view access.

## Changes

### Backend (profiles.py)
- **Added `readonly_calendar` field** to JWT generation workflow for profile management
- Implemented conditional update logic to allow override of read-only calendar setting during profile generation
- Updated profile change detection to track `readonly_calendar` modifications
- Exposed `readonly_calendar` in JWT validation response with default `False` value for backward compatibility

### Frontend (Calendar.jsx)
- **New `readOnly` prop** to control calendar editability
- Disabled interactive calendar features when in read-only mode:
  - Event creation via date selection and clicking
  - Event drag-and-drop functionality
  - Post editing modal
  - Composer modal access
- Maintained full read-access to scheduled posts and media previews
- Conditional rendering of edit actions and buttons based on read-only state

### User Management & Profile Configuration
- Extended ConnectProfile and UserManagement components to support read-only calendar toggle
- Seamless integration with existing white-label profile customization

## Key Features
✅ Preserves calendar view and post preview functionality  
✅ Prevents unauthorized post modifications in white-label contexts  
✅ Backward compatible (defaults to `False`)  
✅ Granular control per client profile  
✅ Consistent enforcement across frontend and API layers  

## Use Case
Ideal for agency white-label implementations where clients need read-only calendar access for compliance, reporting, or tiered permission scenarios.