### PR TITLE
Make TikTok titles optional, doc 90ch limit

### DIFF
--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -280,9 +280,9 @@ const getUserForOperation = (ctx: ExecutionContext, needsUser: boolean): string 
 const prepareUploadBase = (ctx: ExecutionContext, operation: UploadOperation): UploadPreparation => {
 	const formData: IDataObject = {};
 	const user = getUserForOperation(ctx, true);
-	const title = ctx.node.getNodeParameter('title', ctx.itemIndex) as string;
+	const title = ctx.node.getNodeParameter('title', ctx.itemIndex, '') as string;
 	formData.user = user;
-	formData.title = title;
+	if (title) formData.title = title;
 
 	const firstComment = ctx.node.getNodeParameter('firstComment', ctx.itemIndex, '') as string;
 	if (firstComment) {
@@ -1271,9 +1271,9 @@ export class UploadPost implements INodeType {
 				displayName: 'Title / Main Content',
 				name: 'title',
 				type: 'string',
-				required: true,
+				required: false,
 				default: '',
-				description: 'Title of the post. For Upload Text, this is the main text content. For some video platforms, this acts as a fallback for description if a specific description is not provided.',
+				description: 'Title of the post. Required for YouTube, Reddit, and text posts. Optional for TikTok, Instagram, Facebook, LinkedIn, X, Threads, Bluesky, Pinterest. For Upload Text, this is the main text content.',
 				displayOptions: { show: { resource: ['uploads'], operation: ['uploadPhotos','uploadVideo','uploadText','uploadDocument'] } },
 			},
 			{
@@ -1322,7 +1322,7 @@ export class UploadPost implements INodeType {
 					name: 'tiktokTitle',
 					type: 'string',
 					default: '',
-					description: 'Optional override for TikTok title',
+					description: 'Optional override for TikTok title (max 90 chars for photos, 2200 for videos)',
 					displayOptions: { show: { operation: ['uploadPhotos','uploadVideo','uploadText'], platform: ['tiktok', '__manual_platform__'] } },
 				},
 				{


### PR DESCRIPTION
## PR Description: TikTok — Make titles optional & document 90-char limit

### Summary

Makes the title field optional for TikTok (and other platforms that don't strictly require it), aligning the n8n node with updated backend validation. Also documents TikTok's character limits in field descriptions.

### Changes

- **Title field no longer globally required** (`required: false`): Title is now only enforced by the backend for YouTube, Reddit, and text posts. Platforms like TikTok, Instagram, Facebook, LinkedIn, X, Threads, Bluesky, and Pinterest can publish without a title.
- **Updated title field description** to clearly state which platforms require a title vs. where it's optional.
- **Documented TikTok title character limits** in the TikTok Title Override description: max 90 characters for photo posts, 2200 for video posts.
- **Conditional title submission** in `prepareUploadBase`: title is only included in the form data when a non-empty value is provided (`if (title) formData.title = title`), preventing empty strings from being sent to the API.

### Context

Previously, the n8n node required a title for all upload operations regardless of platform. This was overly restrictive — TikTok and several other platforms treat titles as optional. The backend (`sass-ai`) and frontend (`upload-post-app`) have been updated in parallel to enforce title requirements only for platforms that need them (YouTube & Reddit for videos, Reddit for photos), while this PR updates the n8n node definition to match.