### PR TITLE
Add tracking to distinguish n8n vs direct API

### DIFF
--- a/credentials/UploadPostApi.credentials.ts
+++ b/credentials/UploadPostApi.credentials.ts
@@ -30,7 +30,8 @@ export class UploadPostApi implements ICredentialType {
 		type: 'generic',
 		properties: {
 			headers: {
-				'Authorization': '=Apikey {{$credentials.apiKey}}'
+				'Authorization': '=Apikey {{$credentials.apiKey}}',
+				'X-Upload-Post-Source': 'n8n',
 			}
 		},
 	};
@@ -44,6 +45,7 @@ export class UploadPostApi implements ICredentialType {
 			method: 'GET',
 			headers: {
 				'Authorization': '=Apikey {{ $credentials.apiKey }}',
+				'X-Upload-Post-Source': 'n8n',
 			},
 		},
 	};

--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -1140,6 +1140,7 @@ const pollUploadStatus = async (
 			url: `${API_BASE_URL}/uploadposts/status`,
 			method: 'GET',
 			qs: { request_id: requestId },
+			headers: { 'X-Upload-Post-Source': 'n8n' },
 			json: true,
 		};
 		const statusData = await node.helpers.httpRequestWithAuthentication.call(node, 'uploadPostApi', statusOptions);


### PR DESCRIPTION
## Add `X-Upload-Post-Source` header to identify n8n requests

This change adds the `X-Upload-Post-Source: n8n` header to all HTTP requests made by the n8n node, enabling the backend to distinguish n8n-originated traffic from other API clients (npm, pip, dashboard, direct API) in upload statistics.

### Changes

- **`credentials/UploadPostApi.credentials.ts`** — Added `X-Upload-Post-Source: 'n8n'` to both the generic credential authentication headers and the credential test request headers. This ensures all authenticated requests made through n8n's built-in HTTP helpers automatically include the source header.

- **`nodes/UploadPost/UploadPost.node.ts`** — Added `X-Upload-Post-Source: 'n8n'` header to the upload status polling request (`/uploadposts/status`), which constructs its own request options outside of the credential defaults.

### Why

The backend now tracks the origin of each upload request in the `uploadpost_stats` collection via a new `source` field. This header is the mechanism by which each client SDK self-identifies. Without this change, all n8n requests would be classified as generic `api` calls, losing visibility into n8n usage patterns.