### PR TITLE
Add platform limit per queue slot

### DIFF
--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -307,6 +307,10 @@ const prepareUploadBase = (ctx: ExecutionContext, operation: UploadOperation): U
 	const addToQueue = ctx.node.getNodeParameter('addToQueue', ctx.itemIndex, false) as boolean;
 	if (addToQueue) {
 		formData.add_to_queue = 'true';
+		const maxPostsPerSlot = ctx.node.getNodeParameter('maxPostsPerSlot', ctx.itemIndex, 0) as number;
+		if (maxPostsPerSlot > 0) {
+			formData.max_posts_per_slot = String(maxPostsPerSlot);
+		}
 	}
 
 	const uploadAsync = ctx.node.getNodeParameter('uploadAsync', ctx.itemIndex) as boolean;
@@ -1579,6 +1583,14 @@ export class UploadPost implements INodeType {
 				default: false,
 				description: 'Whether to add this post to your configured queue instead of posting immediately. The post will be automatically scheduled to your next available queue slot. Configure your queue settings in the Upload-Post dashboard.',
 				displayOptions: { show: { resource: ['uploads'], operation: ['uploadPhotos','uploadVideo','uploadText','uploadDocument'] } },
+			},
+			{
+				displayName: 'Max Posts Per Slot',
+				name: 'maxPostsPerSlot',
+				type: 'number',
+				default: 0,
+				description: 'Maximum number of posts allowed per queue slot. Overrides the profile setting. Set to 0 to use the profile default. Only used when Add to Queue is enabled.',
+				displayOptions: { show: { resource: ['uploads'], operation: ['uploadPhotos','uploadVideo','uploadText','uploadDocument'], addToQueue: [true] } },
 			},
 			{
 				displayName: 'Upload Asynchronously',


### PR DESCRIPTION
Here's the PR description:

---

## Summary

Adds a new **Max Posts Per Slot** parameter to the n8n Upload-Post node, allowing users to control how many posts can be scheduled into a single queue time slot. This supports the backend queue capacity feature that replaces the previous one-post-per-slot limitation.

## Changes

- **New node parameter `maxPostsPerSlot`** — A numeric field (default `0`) that appears conditionally when "Add to Queue" is enabled. Applies to all upload operations (Photos, Video, Text, Document).
- **Form data passthrough** — When `maxPostsPerSlot > 0`, the value is sent as `max_posts_per_slot` in the upload request, overriding the profile-level default on the backend.
- **Conditional visibility** — The parameter only renders in the n8n UI when `addToQueue` is `true`, keeping the interface clean for non-queue uploads.

## How it works

Previously, each queue slot could hold exactly one post. With this change:

- **Default behavior (`0`)**: Uses the profile's configured `max_posts_per_slot` setting (backend default: 1, preserving backward compatibility).
- **Override (`> 0`)**: Allows the n8n workflow to specify a per-request slot capacity, useful for workflows that batch content across multiple platforms without consuming separate time slots for each.

## Backend context

The corresponding backend changes (in `sass-ai`) introduce slot capacity tracking via a `Counter` instead of a simple `set` of scheduled times, a `full_slots` mechanism, and validation for the `max_posts_per_slot` setting (must be 1–100).