### PR TITLE
Add first_comment support for LinkedIn posts

### DIFF
--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -223,6 +223,7 @@ const FIRST_COMMENT_OVERRIDES: Array<{
 	{ platform: 'youtube', param: 'youtubeFirstComment', field: 'youtube_first_comment', operations: ['uploadVideo'] },
 	{ platform: 'reddit', param: 'redditFirstComment', field: 'reddit_first_comment' },
 	{ platform: 'bluesky', param: 'blueskyFirstComment', field: 'bluesky_first_comment' },
+	{ platform: 'linkedin', param: 'linkedinFirstComment', field: 'linkedin_first_comment' },
 ];
 
 const getFilteredPlatforms = (operation: UploadOperation, platforms: string[]): string[] => {
@@ -1514,6 +1515,14 @@ export class UploadPost implements INodeType {
 				default: '',
 				description: 'Optional override for Bluesky first comment/reply. If provided, overrides the generic First Comment for Bluesky.',
 				displayOptions: { show: { operation: ['uploadPhotos','uploadVideo','uploadText'], platform: ['bluesky', '__manual_platform__'] } },
+			},
+			{
+				displayName: 'LinkedIn First Comment (Override)',
+				name: 'linkedinFirstComment',
+				type: 'string',
+				default: '',
+				description: 'Optional override for LinkedIn first comment. If provided, overrides the generic First Comment for LinkedIn.',
+				displayOptions: { show: { operation: ['uploadPhotos','uploadVideo','uploadText','uploadDocument'], platform: ['linkedin', '__manual_platform__'] } },
 			},
 
 		// Fields for Upload Photo(s)


### PR DESCRIPTION
## Add first_comment support for LinkedIn posts

Extends the existing `first_comment` feature (already available on other platforms like X/Twitter) to LinkedIn, allowing users to automatically post a first comment immediately after publishing a LinkedIn post.

### Changes

- **`social_utils.py`** — Added `post_linkedin_first_comment()` utility function that posts a comment on a newly published LinkedIn post using the `/rest/comments` API endpoint (LinkedIn API version 202510). Includes error handling and logging.

- **`uploaddocuments.py`** — Added `first_comment` parameter to `upload_document_linkedin()` and calls `post_linkedin_first_comment()` after successful document post creation.

- **`uploadphotos.py`** — Added `first_comment` parameter to `upload_photo_linkedin()` and calls `post_linkedin_first_comment()` after successful photo post creation.

- **`uploadtext.py`** — Added `first_comment` parameter to the LinkedIn text upload flow.

- **`uploadvideos.py`** — Added `first_comment` parameter to the LinkedIn video upload flow.

- **`uploadposts.py`** — Wired `first_comment` through all LinkedIn upload orchestration paths (video, photo, document, text). Reads `first_comment` or `linkedin_first_comment` from the request form data and passes it as `platform_first_comment` to each LinkedIn upload function.

### How it works

1. The user provides a `first_comment` (or `linkedin_first_comment`) field in their upload request
2. The post is published to LinkedIn as normal
3. If the post succeeds and returns a valid `post_id`/URN, `post_linkedin_first_comment()` is called
4. The function posts a comment using the actor's credentials against the LinkedIn Comments REST API
5. Success/failure is logged without interrupting the main post result

### n8n node changes

The `UploadPost.node.ts` file was also updated to expose the `first_comment` field in the n8n workflow UI for LinkedIn posts.