### PR TITLE
Add Google Business Profile selection in OAuth

### DIFF
--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -729,6 +729,11 @@ const applyThreadsOptions = (ctx: ExecutionContext, formData: IDataObject) => {
 	}
 };
 
+const applyGoogleBusinessOptions = (ctx: ExecutionContext, _operation: UploadOperation, formData: IDataObject) => {
+	const locationId = ctx.node.getNodeParameter('gbpLocationId', ctx.itemIndex, '') as string;
+	if (locationId) formData.gbp_location_id = locationId;
+};
+
 const applyRedditOptions = (ctx: ExecutionContext, operation: UploadOperation, formData: IDataObject) => {
 	const subreddit = ctx.node.getNodeParameter('redditSubreddit', ctx.itemIndex) as string;
 	const flairId = ctx.node.getNodeParameter('redditFlairId', ctx.itemIndex, '') as string;
@@ -786,6 +791,10 @@ const applyUploadPlatformOptions = async (
 
 	if (platforms.includes('reddit')) {
 		applyRedditOptions(ctx, operation, formData);
+	}
+
+	if (platforms.includes('google_business')) {
+		applyGoogleBusinessOptions(ctx, operation, formData);
 	}
 
 	if (platforms.includes('bluesky') && operation === 'uploadText') {
@@ -2409,6 +2418,16 @@ export class UploadPost implements INodeType {
 						platform: ['threads', '__manual_platform__']
 					},
 				},
+			},
+
+		// ----- Google Business Specific Parameters -----
+			{
+				displayName: 'Google Business Location ID',
+				name: 'gbpLocationId',
+				type: 'string',
+				default: '',
+				description: 'Location ID for accounts with multiple Google Business Profile locations (e.g., accounts/123/locations/456). If omitted, uses the default connected location.',
+				displayOptions: { show: { operation: ['uploadPhotos', 'uploadVideo', 'uploadText'], platform: ['google_business', '__manual_platform__'] } },
 			},
 
 		// ----- Reddit Specific Parameters -----


### PR DESCRIPTION
Now I have a complete picture of the changes. Here's the PR description:

---

## Summary

Adds support for user selection of a specific Google Business Profile location during and after the OAuth connection flow. Previously, the system automatically selected the first available location, which was problematic for accounts managing multiple business locations.

## Changes

### Backend (`sass-ai`)

- **`callbacks.py`** — Modified the Google Business OAuth callback to accept an optional `location_id` parameter. When provided, the callback matches the requested location instead of defaulting to the first one. Returns `needs_location_selection: true` when multiple locations exist and no specific location was requested, signaling the frontend to prompt the user.

- **`platformspecifics.py`** — Added two new endpoints:
  - `GET /api/uploadposts/google-business/locations` — Retrieves all available locations for a connected Google Business account, with an optional `profile` filter. Marks the currently selected location.
  - `POST /api/uploadposts/google-business/locations/select` — Allows switching the active location for a profile after initial OAuth connection.

- **`upload_google_business.py`** — Minor adjustments to support the new location selection flow.

- **`analytics.py`** — Added analytics tracking for location selection events.

### n8n Node (`n8n-nodes-upload-post`)

- **`UploadPost.node.ts`** — Added a `gbpLocationId` parameter to Google Business operations, allowing n8n workflow users to specify a target location ID (e.g., `accounts/123/locations/456`). Falls back to the default connected location when omitted.

## How It Works

1. User initiates Google Business OAuth as before
2. If the account has multiple locations, the callback returns all locations with `needs_location_selection: true`
3. Frontend presents a location picker to the user
4. User's selection is sent back via the callback (with `location_id`) or the new `/locations/select` endpoint
5. For n8n automation, users can optionally specify the location ID directly in the node configuration

## Test Plan

- [ ] OAuth flow with a single-location Google Business account (should behave as before)
- [ ] OAuth flow with a multi-location account (should prompt for selection)
- [ ] Selecting a location via the new `/locations/select` endpoint
- [ ] Requesting a non-existent `location_id` returns 404
- [ ] n8n node posts to the correct location when `gbpLocationId` is specified
- [ ] n8n node falls back to default location when `gbpLocationId` is omitted