### PR TITLE
Add Threads topic tag API support

### DIFF
--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -727,6 +727,11 @@ const applyThreadsOptions = (ctx: ExecutionContext, formData: IDataObject) => {
 			formData.threads_thread_media_layout = threadsThreadMediaLayout;
 		}
 	}
+
+	const threadsTopicTag = ctx.node.getNodeParameter('threadsTopicTag', ctx.itemIndex, '') as string;
+	if (threadsTopicTag) {
+		formData.threads_topic_tag = threadsTopicTag;
+	}
 };
 
 const applyRedditOptions = (ctx: ExecutionContext, operation: UploadOperation, formData: IDataObject) => {
@@ -2409,6 +2414,14 @@ export class UploadPost implements INodeType {
 						platform: ['threads', '__manual_platform__']
 					},
 				},
+			},
+			{
+				displayName: 'Threads Topic Tag',
+				name: 'threadsTopicTag',
+				type: 'string',
+				default: '',
+				description: 'A topic tag for the Threads post (1-50 characters, no periods or ampersands). Helps increase reach on Threads.',
+				displayOptions: { show: { operation: ['uploadPhotos','uploadVideo','uploadText'], platform: ['threads', '__manual_platform__'] } },
 			},
 
 		// ----- Reddit Specific Parameters -----


### PR DESCRIPTION
Here's the PR description:

---

## Summary

Adds support for the Threads **topic tag** feature in the Upload Post n8n node, allowing users to attach a topic tag to Threads posts for improved content discoverability and reach.

## Changes

- **New node parameter**: Added `threadsTopicTag` string parameter to the n8n node UI, visible for photo, video, and text uploads targeting the Threads platform
- **API integration**: `applyThreadsOptions` now reads the topic tag value and passes it as `threads_topic_tag` in the form data sent to the backend API
- **Validation hint**: Parameter description notes the 1-50 character limit and restriction on periods/ampersands (validated server-side in the API)

### Backend (sass-ai)

- **Input validation** in `upload_to_platforms` and `upload_photos_to_platforms`: rejects `threads_topic_tag` values exceeding 50 characters or containing `.` / `&`
- **Photo uploads** (`uploadphotos.py`): Passes `topic_tag` to the Threads Graph API for single-image container creation and carousel publishing
- **Video uploads** (`uploadposts.py`): Forwards `threads_topic_tag` through to `upload_threads`
- **Text uploads** (`uploadtext.py`): Propagated through the text upload path
- **Unused imports** cleaned up in `uploadposts.py` (`refresh_job_summary`, `utcnow`)

## Test plan

- [ ] Upload a text post to Threads with a topic tag and verify it appears on the published post
- [ ] Upload a single photo to Threads with a topic tag
- [ ] Upload a multi-photo carousel to Threads with a topic tag
- [ ] Upload a video to Threads with a topic tag
- [ ] Verify validation rejects tags over 50 characters or containing `.` / `&`
- [ ] Verify omitting the topic tag still works (backwards compatible)
- [ ] Test via n8n node UI that the field only appears when Threads is selected