### PR TITLE
Fix polling to treat 'scheduled' as terminal

### DIFF
--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -1189,7 +1189,7 @@ const pollUploadStatus = async (
 		const statusValue = (statusData && (statusData as any).status) as string | undefined;
 		if (
 			(statusData && (statusData as any).success === true) ||
-			(typeof statusValue === 'string' && ['success', 'completed', 'failed', 'error'].includes(statusValue.toLowerCase()))
+			(typeof statusValue === 'string' && ['success', 'completed', 'failed', 'error', 'scheduled', 'queued', 'pending'].includes(statusValue.toLowerCase()))
 		) {
 			break;
 		}


### PR DESCRIPTION
Now I have full context. Here's the PR description:

---

## Fix n8n node polling to recognize 'scheduled' as a terminal status

### Problem

The n8n node's polling loop did not recognize `scheduled` as a terminal status when checking upload results. When a user scheduled a post (instead of publishing immediately), the polling function would keep polling until timeout because `scheduled` wasn't in the list of statuses that break the polling loop. This caused unnecessary delays and timeout errors for scheduled posts.

### Changes

- **`n8n-nodes-upload-post/nodes/UploadPost/UploadPost.node.ts`** — Updated the `pollForStatus` terminal status list to include `'scheduled'`, `'queued'`, and `'pending'` alongside the existing `'success'`, `'completed'`, `'failed'`, and `'error'` values. When the API returns any of these statuses, the polling loop now correctly breaks and returns the result immediately.

### Before

```typescript
['success', 'completed', 'failed', 'error'].includes(statusValue.toLowerCase())
```

Polling would spin until timeout for scheduled/queued posts.

### After

```typescript
['success', 'completed', 'failed', 'error', 'scheduled', 'queued', 'pending'].includes(statusValue.toLowerCase())
```

Polling exits immediately once the API confirms the post has been scheduled, queued, or is pending.

### Test plan

- [ ] Schedule a post via the n8n Upload Post node and verify polling resolves immediately with `scheduled` status
- [ ] Queue a post and verify polling resolves with `queued` status
- [ ] Verify immediate uploads still resolve correctly with `success`/`completed` status
- [ ] Verify failed uploads still resolve correctly with `failed`/`error` status