### PR TITLE
fix(polling): add scheduled/queued/pending as terminal statuses

### DIFF
--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -1189,7 +1189,7 @@ const pollUploadStatus = async (
 		const statusValue = (statusData && (statusData as any).status) as string | undefined;
 		if (
 			(statusData && (statusData as any).success === true) ||
-			(typeof statusValue === 'string' && ['success', 'completed', 'failed', 'error'].includes(statusValue.toLowerCase()))
+			(typeof statusValue === 'string' && ['success', 'completed', 'failed', 'error', 'scheduled', 'queued', 'pending'].includes(statusValue.toLowerCase()))
 		) {
 			break;
 		}


### PR DESCRIPTION
## Summary
- Adds `scheduled`, `queued`, and `pending` to the terminal status list in `pollUploadStatus` so the n8n node stops polling immediately when a post is confirmed as scheduled for the future, instead of waiting the full 600-second timeout.

## Changes
- `nodes/UploadPost/UploadPost.node.ts`: Added `'scheduled'`, `'queued'`, and `'pending'` to the terminal status array in the `pollUploadStatus` function (line ~1192).

## Context
Multiple customers affected (Chatwoot #1894, #1986). When scheduling posts for a future date, the `waitForCompletion` polling loop would run for up to 10 minutes because statuses like `scheduled` were not recognized as terminal. One customer (Spencer California) schedules ~260 monthly posts, each hanging for up to 10 minutes.

## Testing
1. Create a scheduled post via n8n with `waitForCompletion` enabled
2. Verify the node returns immediately with the job data once status is `scheduled`/`queued`/`pending`
3. Verify existing behavior for `success`/`completed`/`failed`/`error` statuses is unchanged

Co-Authored-By: Claude (noreply@anthropic.com)