### PR TITLE
feat(instagram): support binary data for Instagram Reels cover

### DIFF
--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -2385,7 +2385,7 @@ export class UploadPost implements INodeType {
 				name: 'instagramCoverUrl',
 				type: 'string',
 				default: '',
-				description: 'URL or binary property name for custom video cover on Instagram. If a URL (http/https) is provided, it is sent directly. If a binary property name is provided, the image is uploaded and converted to a public URL automatically. Must be JPEG, ≤ 8MB. Only for Upload Video.',
+				description: 'URL or binary property name for custom video cover on Instagram. Binary images are uploaded and converted to a public URL automatically. JPEG, ≤ 8MB.',
 				displayOptions: {
 					show: {
 						operation: ['uploadVideo'],

--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -504,7 +504,7 @@ const applyTiktokOptions = (ctx: ExecutionContext, operation: UploadOperation, f
 	}
 };
 
-const applyInstagramOptions = (ctx: ExecutionContext, operation: UploadOperation, formData: IDataObject) => {
+const applyInstagramOptions = async (ctx: ExecutionContext, operation: UploadOperation, formData: IDataObject) => {
 	const providedMediaType = ctx.node.getNodeParameter('instagramMediaType', ctx.itemIndex, '') as string;
 	let finalMediaType = providedMediaType;
 	if (operation === 'uploadPhotos') {
@@ -541,7 +541,14 @@ const applyInstagramOptions = (ctx: ExecutionContext, operation: UploadOperation
 		if (shareMode && shareMode !== 'CUSTOM') {
 			formData.share_mode = shareMode;
 		}
-		if (coverUrl) formData.cover_url = coverUrl;
+		if (coverUrl) {
+			if (isUrlString(coverUrl)) {
+				formData.cover_url = coverUrl;
+			} else {
+				const coverBinary = await getBinaryFieldFromItem(ctx, coverUrl, 'Binary data for Instagram cover property');
+				formData.cover_image = coverBinary;
+			}
+		}
 		if (audioName) formData.audio_name = audioName;
 		if (thumbOffset) formData.thumb_offset = thumbOffset;
 	}
@@ -780,7 +787,7 @@ const applyUploadPlatformOptions = async (
 	}
 
 	if (platforms.includes('instagram')) {
-		applyInstagramOptions(ctx, operation, formData);
+		await applyInstagramOptions(ctx, operation, formData);
 	}
 
 	if (platforms.includes('youtube') && operation === 'uploadVideo') {
@@ -2374,11 +2381,11 @@ export class UploadPost implements INodeType {
 				},
 			},
 			{
-				displayName: 'Instagram Cover URL (Video)',
+				displayName: 'Instagram Cover URL or Binary (Video)',
 				name: 'instagramCoverUrl',
 				type: 'string',
 				default: '',
-				description: 'URL for custom video cover on Instagram. Only for Upload Video.',
+				description: 'URL or binary property name for custom video cover on Instagram. If a URL (http/https) is provided, it is sent directly. If a binary property name is provided, the image is uploaded and converted to a public URL automatically. Must be JPEG, ≤ 8MB. Only for Upload Video.',
 				displayOptions: {
 					show: {
 						operation: ['uploadVideo'],


### PR DESCRIPTION
## Summary
- Add binary property detection for `instagramCoverUrl` using `isUrlString()`, matching YouTube thumbnail pattern
- When a binary property name is provided instead of a URL, the image is sent as a `cover_image` multipart file for backend CDN upload
- Update property description to indicate both URL and binary property names are accepted

## Changes
- Make `applyInstagramOptions` async to support `getBinaryFieldFromItem()`
- Add `isUrlString()` check for cover URL: URLs go to `cover_url`, binary names go to `cover_image`
- Update field display name and description to document dual-mode support

## Testing
- Set `instagramCoverUrl` to a URL like `https://example.com/cover.jpg` — should send as `cover_url` (existing behavior)
- Set `instagramCoverUrl` to a binary property name like `data` — should send as `cover_image` binary file upload
- Verify YouTube thumbnail binary support still works unchanged

Co-Authored-By: Claude (noreply@anthropic.com)