### PR TITLE
feat(webhooks): add notification preferences operations

### DIFF
--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -1088,6 +1088,32 @@ const buildUserRequest = (ctx: ExecutionContext): RequestConfig => {
 				waitForCompletion: false,
 			};
 		}
+		case 'getNotificationPrefs': {
+			return {
+				endpoint: '/uploadposts/users/notifications',
+				method: 'GET',
+				body: {},
+				isUploadOperation: false,
+				waitForCompletion: false,
+			};
+		}
+		case 'updateNotificationPrefs': {
+			const webhookUrl = ctx.node.getNodeParameter('webhookUrl', ctx.itemIndex, '') as string;
+			const webhookEnabled = ctx.node.getNodeParameter('webhookEnabled', ctx.itemIndex, false) as boolean;
+			const webhookEventsRaw = ctx.node.getNodeParameter('webhookEvents', ctx.itemIndex, []) as string[];
+			const body: Record<string, unknown> = {
+				channels: { webhook: webhookEnabled },
+			};
+			if (webhookUrl) body.webhook_url = webhookUrl;
+			if (webhookEventsRaw.length > 0) body.webhook_events = webhookEventsRaw;
+			return {
+				endpoint: '/uploadposts/users/notifications',
+				method: 'POST',
+				body,
+				isUploadOperation: false,
+				waitForCompletion: false,
+			};
+		}
 		default:
 			throw new NodeOperationError(ctx.node.getNode(), `Unsupported user operation: ${ctx.operation}`, {
 				itemIndex: ctx.itemIndex,
@@ -1273,7 +1299,9 @@ export class UploadPost implements INodeType {
 					{ name: 'Create User', value: 'createUser', action: 'Create user', description: 'Create a new Upload-Post user (profile name)' },
 					{ name: 'Delete User', value: 'deleteUser', action: 'Delete user', description: 'Delete an existing Upload-Post user by profile name' },
 					{ name: 'Generate JWT (for Platform Integration)', value: 'generateJwt', action: 'Generate jwt for platform integration', description: 'Generate a connection URL (JWT) for a profile. Only needed when integrating Upload-Post into your own platform.' },
+					{ name: 'Get Notification Preferences', value: 'getNotificationPrefs', action: 'Get notification preferences', description: 'Get current webhook and notification settings' },
 					{ name: 'List Users', value: 'listUsers', action: 'List users', description: 'List Upload-Post users (profiles)' },
+					{ name: 'Update Notification Preferences', value: 'updateNotificationPrefs', action: 'Update notification preferences', description: 'Configure webhook URL and event types for real-time notifications (upload_completed, social_account.connected, social_account.disconnected, social_account.reauth_required)' },
 					{ name: 'Validate JWT (for Platform Integration)', value: 'validateJwt', action: 'Validate jwt for platform integration', description: 'Validate a connection token from your backend. Only needed for custom platform integration.' },
 				],
 				default: 'listUsers',
@@ -1901,6 +1929,39 @@ export class UploadPost implements INodeType {
 				default: '',
 				description: 'JWT to validate',
 				displayOptions: { show: { operation: ['validateJwt'] } },
+			},
+
+			// Update Notification Preferences
+			{
+				displayName: 'Webhook Enabled',
+				name: 'webhookEnabled',
+				type: 'boolean',
+				default: true,
+				description: 'Whether to enable webhook notifications',
+				displayOptions: { show: { operation: ['updateNotificationPrefs'] } },
+			},
+			{
+				displayName: 'Webhook URL',
+				name: 'webhookUrl',
+				type: 'string',
+				default: '',
+				placeholder: 'https://your-server.com/webhook',
+				description: 'URL to receive webhook POST requests',
+				displayOptions: { show: { operation: ['updateNotificationPrefs'] } },
+			},
+			{
+				displayName: 'Webhook Events',
+				name: 'webhookEvents',
+				type: 'multiOptions',
+				options: [
+					{ name: 'Upload Completed', value: 'upload_completed', description: 'When a post upload finishes (success or failure)' },
+					{ name: 'Account Connected', value: 'social_account.connected', description: 'When a social account is connected or reconnected' },
+					{ name: 'Account Disconnected', value: 'social_account.disconnected', description: 'When a social account is disconnected' },
+					{ name: 'Re-auth Required', value: 'social_account.reauth_required', description: 'When a social account needs re-authentication' },
+				],
+				default: ['upload_completed', 'social_account.connected', 'social_account.disconnected', 'social_account.reauth_required'],
+				description: 'Which webhook events to subscribe to',
+				displayOptions: { show: { operation: ['updateNotificationPrefs'] } },
 			},
 
 		// ----- LinkedIn Specific Parameters -----


### PR DESCRIPTION
## Summary
- Add Get/Update Notification Preferences operations to the User resource in the n8n node
- Users can configure webhook URL and select which events to subscribe to

## Changes
- **UploadPost.node.ts**: Add getNotificationPrefs and updateNotificationPrefs operations with webhookUrl, webhookEnabled, and webhookEvents (multiOptions) parameters

## Testing
- Verify new operations appear in n8n node UI under User resource
- Test Get Notification Preferences returns current settings
- Test Update Notification Preferences saves webhook URL and event types

Co-Authored-By: Claude (noreply@anthropic.com)