### PR TITLE
feat(youtube): expose Playlist ID field for video uploads

### DIFF
--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -597,7 +597,7 @@ const applyYoutubeOptions = async (ctx: ExecutionContext, formData: IDataObject)
 	if (blockedCountries) formData.blockedCountries = blockedCountries;
 	formData.hasPaidProductPlacement = String(hasPaidProductPlacement);
 	if (recordingDate) formData.recordingDate = recordingDate;
-	if (playlistId && playlistId.trim()) formData.youtube_playlist_id = playlistId.trim();
+	if (playlistId) formData.youtube_playlist_id = playlistId;
 };
 
 const validateXPollConfiguration = (

--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -587,6 +587,7 @@ const applyYoutubeOptions = async (ctx: ExecutionContext, formData: IDataObject)
 	const blockedCountries = ctx.node.getNodeParameter('youtubeBlockedCountries', ctx.itemIndex, '') as string;
 	const hasPaidProductPlacement = ctx.node.getNodeParameter('youtubeHasPaidProductPlacement', ctx.itemIndex, false) as boolean;
 	const recordingDate = ctx.node.getNodeParameter('youtubeRecordingDate', ctx.itemIndex, '') as string;
+	const playlistId = ctx.node.getNodeParameter('youtubePlaylistId', ctx.itemIndex, '') as string;
 
 	formData.selfDeclaredMadeForKids = String(selfDeclaredMadeForKids);
 	formData.containsSyntheticMedia = String(containsSyntheticMedia);
@@ -596,6 +597,7 @@ const applyYoutubeOptions = async (ctx: ExecutionContext, formData: IDataObject)
 	if (blockedCountries) formData.blockedCountries = blockedCountries;
 	formData.hasPaidProductPlacement = String(hasPaidProductPlacement);
 	if (recordingDate) formData.recordingDate = recordingDate;
+	if (playlistId && playlistId.trim()) formData.youtube_playlist_id = playlistId.trim();
 };
 
 const validateXPollConfiguration = (
@@ -2931,6 +2933,19 @@ export class UploadPost implements INodeType {
 				type: 'dateTime',
 				default: '',
 				description: 'Recording timestamp (ISO 8601 format). Only for Upload Video.',
+				displayOptions: {
+					show: {
+						operation: ['uploadVideo'],
+						platform: ['youtube', '__manual_platform__']
+					},
+				},
+			},
+			{
+				displayName: 'YouTube Playlist ID',
+				name: 'youtubePlaylistId',
+				type: 'string',
+				default: '',
+				description: 'Optional YouTube playlist ID (e.g. PLxxxxxxxxxxxx) to add the uploaded video to after publishing. For multiple playlists, pass a comma-separated list of IDs. The playlist must belong to the same YouTube channel that owns the upload. Only for Upload Video.',
 				displayOptions: {
 					show: {
 						operation: ['uploadVideo'],


### PR DESCRIPTION
## Summary

Adds a `YouTube Playlist ID` input on the n8n Upload Video operation so users can add the uploaded video to one or more YouTube playlists on the connected channel. Paired with the sass-ai backend change (Chatwoot #2543 / TT-882).

## Changes

- `nodes/UploadPost/UploadPost.node.ts`:
  - Add a `youtubePlaylistId` string parameter shown only for `uploadVideo` + the YouTube platform.
  - In `applyYoutubeOptions`, read the value and (when non-empty) append `youtube_playlist_id` to the multipart form.
  - The field accepts a single ID like `PLxxxxxxxxxxxx` or a comma-separated list for multiple playlists.

## Testing

- [ ] In n8n, configure Upload Video with platform `YouTube` and set Playlist ID to a valid playlist; verify the uploaded video appears in that playlist
- [ ] Use a comma-separated list of two playlist IDs; verify the video appears in both
- [ ] Leave the Playlist ID field empty; verify no regression on YouTube uploads

Co-Authored-By: Claude (noreply@anthropic.com)