### PR TITLE
Release Staging to Production

### DIFF
--- a/nodes/UploadPost/UploadPost.node.ts
+++ b/nodes/UploadPost/UploadPost.node.ts
@@ -323,6 +323,12 @@ const prepareUploadBase = (ctx: ExecutionContext, operation: UploadOperation): U
 	const uploadAsync = ctx.node.getNodeParameter('uploadAsync', ctx.itemIndex) as boolean;
 	formData.async_upload = String(uploadAsync);
 
+	// AI auto-generation of native per-platform copy from the media (fills blank fields)
+	const autogenerate = ctx.node.getNodeParameter('autogenerate', ctx.itemIndex, false) as boolean;
+	if (autogenerate) {
+		formData.autogenerate = 'true';
+	}
+
 	const rawPlatforms = ctx.node.getNodeParameter('platform', ctx.itemIndex) as string[];
 	const platforms = getFilteredPlatforms(operation, Array.isArray(rawPlatforms) ? rawPlatforms : []);
 	formData['platform[]'] = platforms;
@@ -1859,6 +1865,18 @@ export class UploadPost implements INodeType {
 				displayOptions: {
 					show: {
 						operation: ['uploadPhotos','uploadVideo','uploadText','uploadDocument']
+					}
+				},
+			},
+			{
+				displayName: 'Autogenerate Copy With AI',
+				name: 'autogenerate',
+				type: 'boolean',
+				default: false,
+				description: 'Whether the server should use AI to generate native per-platform title/description from the media and fill any platform field left empty',
+				displayOptions: {
+					show: {
+						operation: ['uploadPhotos','uploadVideo']
 					}
 				},
 			},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-upload-post",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "description": "n8n community node for Upload Post",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## 📦 Release Summary: staging → production

**1 commits** | **2 files changed** | **+19/-1 lines**

### Commits
- `7940648` feat: Autogenerate Copy With AI option on upload nodes; bump 0.1.49 -> 0.1.50 — *victormanuel.caverogracia*

### Files Changed by Area

**(root)/** (1 files)
  ✏️ `package.json` (+1/-1)

**nodes/** (1 files)
  ✏️ `nodes/UploadPost/UploadPost.node.ts` (+18/-0)

---
*Generated automatically by AI Coder*